### PR TITLE
Added minimum PHP version requirement.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "source": "http://dev.entidi.com/p/silverstripe-autotoc/source/tree/master/"
     },
     "require": {
+        "php": ">=5.3.6",
         "silverstripe/framework": "~3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Thanks for merging my previous tweak! This one is even subtler, so won't require a ton of consideration ;)

Due to your use of the `DOMNode` parameter on `DOMDocument::saveHTML()`, which was [added in PHP 5.3.6](http://php.net/manual/en/domdocument.savehtml.php), this module does not work on Debian Squeeze and other similar distros still using PHP 5.3.3.

Theoretically, given that Squeeze and PHP 5.3 are both very deprecated and unsupported, there shouldn't be any servers left running them, but I'm sure you know as well as I do how slowly some organisations move on these things!

I've added a minimum PHP version requirement to the Composer configuration, so anyone silly enough to try installing this code on such an old system won't shoot themselves in the foot.
